### PR TITLE
Add `private_key_jwt` client authentication method

### DIFF
--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -225,7 +225,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             "jti": secrets.token_hex(16),
             "exp": int(time.time()) + 300,  # 5 minutes from now
         }
-        LOGGER.debug("get_token.jwt_args", jwt_args)
+        LOGGER.debug("get_token.jwt_args: {}".format(json.dumps(jwt_args)))
 
         # Client secret needs to be pem-encoded string
         encoded_jwt = jwt.encode(
@@ -234,7 +234,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             algorithm=self.OIDC_RP_SIGN_ALGO
         )
 
-        LOGGER.debug("get_token original payload", payload)
+        LOGGER.debug("get_token original payload: {}".format(json.dumps(payload)))
 
         token_payload = {
             "client_assertion": encoded_jwt,
@@ -243,7 +243,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             "grant_type": "authorization_code",
         }
 
-        LOGGER.debug("get_token.token_payload", token_payload)
+        LOGGER.debug("get_token.token_payload {}".format(json.dumps(token_payload)))
         response = requests.post(self.OIDC_OP_TOKEN_ENDPOINT, data=token_payload)
 
         return response.json()
@@ -283,7 +283,7 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         redirect_uri = absolutify(self.request, reverse(reverse_url))
 
-        LOGGER.debug("authenticate.redirect_uri", redirect_uri)
+        LOGGER.debug("authenticate.redirect_uri: {}".format({redirect_uri}))
 
         token_payload = {
             'client_id': self.OIDC_RP_CLIENT_ID,

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -264,8 +264,6 @@ class OIDCAuthenticationBackend(ModelBackend):
         LOGGER.debug("get_token.token_payload {}".format(json.dumps(token_payload)))
         response = requests.post(self.OIDC_OP_TOKEN_ENDPOINT, data=token_payload)
 
-        add_state_to_cookie(response, state)
-
         return response.json()
 
 
@@ -324,6 +322,7 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         if payload:
             self.store_tokens(access_token, id_token)
+            add_state_to_cookie(state)
             try:
                 return self.get_or_create_user(access_token, id_token, payload)
             except SuspiciousOperation as exc:

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import requests
+from requests.auth import HTTPBasicAuth
 # logindotgov-oidc
 import secrets
 import time

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -246,6 +246,10 @@ class OIDCAuthenticationBackend(ModelBackend):
             "jti": secrets.token_hex(16),
             "exp": int(time.time()) + 300,  # 5 minutes from now
         }
+        print("jwt_args", jwt_args)
+        print("self.OIDC_RP_CLIENT_SECRET", self.OIDC_RP_CLIENT_SECRET)
+        print("self.OIDC_RP_SIGN_ALGO", self.OIDC_RP_SIGN_ALGO)
+        # Is client secret pem-encoded? Used Sublime to remove newlines
         encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET, algorithm=self.OIDC_RP_SIGN_ALGO)
 
         payload = {

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -301,15 +301,16 @@ class OIDCAuthenticationBackend(ModelBackend):
         reverse_url = self.get_settings('OIDC_AUTHENTICATION_CALLBACK_URL',
                                         'oidc_authentication_callback')
 
+        redirect_uri = absolutify(self.request, reverse(reverse_url))
+
+        print("authenticate.redirect_uri", redirect_uri)
+
         token_payload = {
             'client_id': self.OIDC_RP_CLIENT_ID,
             'client_secret': self.OIDC_RP_CLIENT_SECRET,
             'grant_type': 'authorization_code',
             'code': code,
-            'redirect_uri': absolutify(
-                self.request,
-                reverse(reverse_url)
-            ),
+            'redirect_uri': redirect_uri,
         }
 
         # Get the token

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -21,7 +21,7 @@ from josepy.b64 import b64decode
 from josepy.jwk import JWK
 from josepy.jws import JWS, Header
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings, add_state_to_cookie
+from mozilla_django_oidc.utils import absolutify, import_from_settings
 
 LOGGER = logging.getLogger(__name__)
 
@@ -322,7 +322,6 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         if payload:
             self.store_tokens(access_token, id_token)
-            add_state_to_cookie(state)
             try:
                 return self.get_or_create_user(access_token, id_token, payload)
             except SuspiciousOperation as exc:

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -82,9 +82,9 @@ class OIDCAuthenticationBackend(ModelBackend):
         if not unique_identifier_value:
             return self.UserModel.objects.none()
         # TODO: Fix this filter
-        # filter_label = UNIQUE_IDENTIFIER + "__iexact"
         filter_label = UNIQUE_IDENTIFIER + "__iexact"
-        return self.UserModel.objects.filter(filter_label=unique_identifier_value)
+        kwargs = {filter_label: unique_identifier_value}
+        return self.UserModel.objects.filter(**kwargs)
 
     def verify_claims(self, claims):
         """Verify the provided claims to decide if authentication should be allowed."""

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -84,7 +84,10 @@ class OIDCAuthenticationBackend(ModelBackend):
         """Verify the provided claims to decide if authentication should be allowed."""
 
         # Verify claims required by default configuration
+        LOGGER.debug("verify_claims.claims (user_info", json.dumps(claims))
         scopes = self.get_settings('OIDC_RP_SCOPES', 'openid email')
+
+        # TODO: Swap out for openID/sub?
         if 'email' in scopes.split():
             return 'email' in claims
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -255,16 +255,16 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         print("original payload", payload)
 
-        payload = {
+        token_payload = {
             "client_assertion": encoded_jwt,
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "code": code,
-            "grant_type": GRANT_TYPE,
+            "code": payload.get("code"),
+            "grant_type": "authorization_code",
         }
 
         # Not sure why debug isn't working, switching to print for now
-        print("payload", payload)
-        response = requests.post(self.OIDC_OP_TOKEN_ENDPOINT, data=payload)
+        print("token_payload", token_payload)
+        response = requests.post(self.OIDC_OP_TOKEN_ENDPOINT, data=token_payload)
 
         return response.json()
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -240,8 +240,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         # logindotgov-oidc, modified
         jwt_args = {
-            "iss": payload.get('client_id'),
-            "sub": payload.get('client_id'),
+            "iss": self.OIDC_RP_CLIENT_ID,
+            "sub": self.OIDC_RP_CLIENT_ID,
             "aud": self.OIDC_OP_TOKEN_ENDPOINT,
             "jti": secrets.token_hex(16),
             "exp": int(time.time()) + 300,  # 5 minutes from now

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -216,7 +216,10 @@ class OIDCAuthenticationBackend(ModelBackend):
         return payload
 
     def get_token(self, payload):
-        """Return token object as a dictionary. Borrowed from logindotgov-oidc, modified"""
+        """Return token object as a dictionary.
+        Borrowed from logindotgov-oidc, modified
+        https://github.com/trussworks/logindotgov-oidc-py
+        """
 
         jwt_args = {
             "iss": self.OIDC_RP_CLIENT_ID,
@@ -261,6 +264,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             verify=self.get_settings('OIDC_VERIFY_SSL', True),
             timeout=self.get_settings('OIDC_TIMEOUT', None),
             proxies=self.get_settings('OIDC_PROXY', None))
+        LOGGER.debug("get_userinfo.user_response: {}".format(json.dumps(user_response.json())))
         user_response.raise_for_status()
         return user_response.json()
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -246,7 +246,7 @@ class OIDCAuthenticationBackend(ModelBackend):
             "jti": secrets.token_hex(16),
             "exp": int(time.time()) + 300,  # 5 minutes from now
         }
-        encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET, algorithm=SIGNING_ALGO)
+        encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET, algorithm=self.OIDC_RP_SIGN_ALGO)
 
         payload = {
             "client_assertion": encoded_jwt,

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -107,9 +107,17 @@ class OIDCAuthenticationBackend(ModelBackend):
         """Return object for a newly created user account."""
         email = claims.get('email')
         uuid = claims.get('sub')
+        first_name = claims.get('given_name')
+        last_name = claims.get('family_name')
         username = self.get_username(claims)
         # TODO: Temporarily put uuid in last_name
-        return self.UserModel.objects.create_user(username, email=email, last_name=uuid)
+        return self.UserModel.objects.create_user(
+            username,
+            email=email,
+            first_name=first_name,
+            last_name=last_name,
+            uuid=uuid
+        )
 
     def get_username(self, claims):
         """Generate username based on claims."""

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -127,6 +127,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     def update_user(self, user, claims):
         """Update existing user with new claims, if necessary save, and return user"""
+
+        # TODO: This isn't built out
         return user
 
     def _verify_jws(self, payload, key):

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -54,7 +54,7 @@ class OIDCAuthenticationBackend(ModelBackend):
         self.OIDC_OP_USER_ENDPOINT = self.get_settings('OIDC_OP_USER_ENDPOINT')
         self.OIDC_OP_JWKS_ENDPOINT = self.get_settings('OIDC_OP_JWKS_ENDPOINT', None)
         self.OIDC_RP_CLIENT_ID = self.get_settings('OIDC_RP_CLIENT_ID')
-        self.OIDC_RP_CLIENT_SECRET = str(self.get_settings('OIDC_RP_CLIENT_SECRET'))
+        self.OIDC_RP_CLIENT_SECRET = self.get_settings('OIDC_RP_CLIENT_SECRET')
         self.OIDC_RP_SIGN_ALGO = self.get_settings('OIDC_RP_SIGN_ALGO', 'HS256')
         self.OIDC_RP_IDP_SIGN_KEY = self.get_settings('OIDC_RP_IDP_SIGN_KEY', None)
 
@@ -249,8 +249,10 @@ class OIDCAuthenticationBackend(ModelBackend):
         print("jwt_args", jwt_args)
         print("self.OIDC_RP_CLIENT_SECRET", self.OIDC_RP_CLIENT_SECRET)
         print("self.OIDC_RP_SIGN_ALGO", self.OIDC_RP_SIGN_ALGO)
+        print("what is OIDC_RP_CLIENT_SECRET", type(self.OIDC_RP_CLIENT_SECRET))
+        print("decoded", self.OIDC_RP_CLIENT_SECRET.decode())
         # Is client secret pem-encoded? Used Sublime to remove newlines
-        encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET, algorithm=self.OIDC_RP_SIGN_ALGO)
+        encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET.decode(), algorithm=self.OIDC_RP_SIGN_ALGO)
 
         payload = {
             "client_assertion": encoded_jwt,

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -92,7 +92,12 @@ class OIDCAuthenticationBackend(ModelBackend):
         # Use the app label to filter
         filter_label = self.OIDC_RP_UNIQUE_IDENTIFIER + "__iexact"
         kwargs = {filter_label: unique_identifier_value}
-        return self.UserModel.objects.filter(**kwargs)
+        LOGGER.debug("filter_label", filter_label)
+        LOGGER.debug("unique_identifier_value", unique_identifier_value)
+        filtered_users = self.UserModel.objects.filter(**kwargs)
+        LOGGER.debug("filtered_users query", filtered_users.query)
+
+        return filtered_users
 
     def verify_claims(self, claims):
         """Verify the provided claims to decide if authentication should be allowed."""

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -21,7 +21,7 @@ from josepy.b64 import b64decode
 from josepy.jwk import JWK
 from josepy.jws import JWS, Header
 
-from mozilla_django_oidc.utils import absolutify, import_from_settings
+from mozilla_django_oidc.utils import absolutify, import_from_settings, add_state_to_cookie
 
 LOGGER = logging.getLogger(__name__)
 
@@ -263,6 +263,8 @@ class OIDCAuthenticationBackend(ModelBackend):
 
         LOGGER.debug("get_token.token_payload {}".format(json.dumps(token_payload)))
         response = requests.post(self.OIDC_OP_TOKEN_ENDPOINT, data=token_payload)
+
+        add_state_to_cookie(response, state)
 
         return response.json()
 

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -249,10 +249,9 @@ class OIDCAuthenticationBackend(ModelBackend):
         print("jwt_args", jwt_args)
         print("self.OIDC_RP_CLIENT_SECRET", self.OIDC_RP_CLIENT_SECRET)
         print("self.OIDC_RP_SIGN_ALGO", self.OIDC_RP_SIGN_ALGO)
-        print("what is OIDC_RP_CLIENT_SECRET", type(self.OIDC_RP_CLIENT_SECRET))
-        print("decoded", self.OIDC_RP_CLIENT_SECRET.decode())
+
         # Is client secret pem-encoded? Used Sublime to remove newlines
-        encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET.decode(), algorithm=self.OIDC_RP_SIGN_ALGO)
+        encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET, algorithm=self.OIDC_RP_SIGN_ALGO)
 
         payload = {
             "client_assertion": encoded_jwt,

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -253,6 +253,8 @@ class OIDCAuthenticationBackend(ModelBackend):
         # Is client secret pem-encoded? Used Sublime to remove newlines
         encoded_jwt = jwt.encode(jwt_args, self.OIDC_RP_CLIENT_SECRET, algorithm=self.OIDC_RP_SIGN_ALGO)
 
+        print("original payload", payload)
+
         payload = {
             "client_assertion": encoded_jwt,
             "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -255,7 +255,8 @@ class OIDCAuthenticationBackend(ModelBackend):
             "grant_type": GRANT_TYPE,
         }
 
-        LOGGER.debug("payload", payload)
+        # Not sure why debug isn't working, switching to print for now
+        print("payload", payload)
         response = requests.post(self.OIDC_OP_TOKEN_ENDPOINT, data=payload)
 
         return response.json()

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -151,9 +151,10 @@ class OIDCAuthenticationBackend(ModelBackend):
         return default_username_algo(self.get_idp_unique_id_value(claims))
 
     def update_user(self, user, claims):
-        """Update existing user with new claims, if necessary save, and return user"""
+        """Update existing user with new email, if necessary save, and return user"""
 
-        # TODO: This isn't built out
+        user.email = claims.get("email")
+        user.save()
         return user
 
     def _verify_jws(self, payload, key):

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -329,6 +329,10 @@ class OIDCAuthenticationBackend(ModelBackend):
         """Returns a User instance if 1 user is found. Creates a user if not found
         and configured to do so. Returns nothing if multiple users are matched."""
 
+        LOGGER.debug("get_or_create_user.access_token", access_token)
+        LOGGER.debug("get_or_create_user.id_token", id_token)
+        LOGGER.debug("get_or_create_user.json.dumps(payload)", json.dumps(payload))
+
         user_info = self.get_userinfo(access_token, id_token, payload)
 
         claims_verified = self.verify_claims(user_info)

--- a/mozilla_django_oidc/auth.py
+++ b/mozilla_django_oidc/auth.py
@@ -54,7 +54,7 @@ class OIDCAuthenticationBackend(ModelBackend):
         self.OIDC_OP_USER_ENDPOINT = self.get_settings('OIDC_OP_USER_ENDPOINT')
         self.OIDC_OP_JWKS_ENDPOINT = self.get_settings('OIDC_OP_JWKS_ENDPOINT', None)
         self.OIDC_RP_CLIENT_ID = self.get_settings('OIDC_RP_CLIENT_ID')
-        self.OIDC_RP_CLIENT_SECRET = self.get_settings('OIDC_RP_CLIENT_SECRET')
+        self.OIDC_RP_CLIENT_SECRET = str(self.get_settings('OIDC_RP_CLIENT_SECRET'))
         self.OIDC_RP_SIGN_ALGO = self.get_settings('OIDC_RP_SIGN_ALGO', 'HS256')
         self.OIDC_RP_IDP_SIGN_KEY = self.get_settings('OIDC_RP_IDP_SIGN_KEY', None)
 

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -160,6 +160,7 @@ class SessionRefresh(MiddlewareMixin):
         add_state_and_nonce_to_session(request, state, params)
 
         #TODO: How do we update the cookie with state?
+        add_state_to_cookie(state)
 
         request.session['oidc_login_next'] = request.get_full_path()
 

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -159,9 +159,6 @@ class SessionRefresh(MiddlewareMixin):
 
         add_state_and_nonce_to_session(request, state, params)
 
-        #TODO: How do we update the cookie with state?
-        add_state_to_cookie(state)
-
         request.session['oidc_login_next'] = request.get_full_path()
 
         query = urlencode(params, quote_via=quote)
@@ -178,4 +175,8 @@ class SessionRefresh(MiddlewareMixin):
             response = JsonResponse({'refresh_url': redirect_url}, status=403)
             response['refresh_url'] = redirect_url
             return response
-        return HttpResponseRedirect(redirect_url)
+
+        response = HttpResponseRedirect(redirect_url)
+        add_state_to_cookie(response, state)
+
+        return response

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -12,6 +12,7 @@ from django.utils.module_loading import import_string
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 from mozilla_django_oidc.utils import (absolutify,
                                        add_state_and_nonce_to_session,
+                                       add_state_to_cookie,
                                        import_from_settings)
 
 from urllib.parse import quote, urlencode
@@ -157,6 +158,9 @@ class SessionRefresh(MiddlewareMixin):
             })
 
         add_state_and_nonce_to_session(request, state, params)
+
+        add_state_to_cookie(request, state)
+
 
         request.session['oidc_login_next'] = request.get_full_path()
 

--- a/mozilla_django_oidc/middleware.py
+++ b/mozilla_django_oidc/middleware.py
@@ -159,8 +159,7 @@ class SessionRefresh(MiddlewareMixin):
 
         add_state_and_nonce_to_session(request, state, params)
 
-        add_state_to_cookie(request, state)
-
+        #TODO: How do we update the cookie with state?
 
         request.session['oidc_login_next'] = request.get_full_path()
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -101,12 +101,12 @@ def add_state_and_nonce_to_session(request, state, params):
         'added_on': time.time(),
     }
 
-def add_state_to_cookie(request, state):
+def add_state_to_cookie(response, state):
     """
     Adds state to cookie for logout
     """
 
     # TODO: Does this overwrite an existing state cookie?
 
-    request.set_cookie("oidc_state", state)
+    response.set_cookie("oidc_state", state)
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -4,6 +4,7 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
 
 from urllib.request import parse_http_list, parse_keqv_list
 
@@ -101,12 +102,12 @@ def add_state_and_nonce_to_session(request, state, params):
         'added_on': time.time(),
     }
 
-def add_state_to_cookie(response, state):
+def add_state_to_cookie(state):
     """
     Adds state to cookie for logout
     """
 
-    # TODO: Does this overwrite an existing state cookie?
-
-    response.set_cookie("oidc_state", state)
+    # Cookies can only be added on response objects, so spoof one
+    response = HttpResponse('add_state_to_cookie')
+    response.set_cookie('oidc_state', state)
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -106,7 +106,7 @@ def add_state_to_cookie(response, state):
     """
     Adds state to cookie for logout
     """
-
+    # TODO: add test cookie. If no cookie, end all sessions
     response.set_cookie('oidc_state', state)
 
     return response

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -107,7 +107,7 @@ def add_state_to_cookie(response, state):
     Adds state to cookie for logout
     """
     # TODO: add test cookie. If no cookie, end all sessions
-    response.set_cookie('oidc_state', state)
+    response.set_signed_cookie('oidc_state', state)
 
     return response
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -102,12 +102,12 @@ def add_state_and_nonce_to_session(request, state, params):
         'added_on': time.time(),
     }
 
-def add_state_to_cookie(state):
+def add_state_to_cookie(response, state):
     """
     Adds state to cookie for logout
     """
 
-    # Cookies can only be added on response objects, so spoof one
-    response = HttpResponse('add_state_to_cookie')
     response.set_cookie('oidc_state', state)
+
+    return response
 

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -4,7 +4,6 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.http import HttpResponse
 
 from urllib.request import parse_http_list, parse_keqv_list
 
@@ -102,6 +101,7 @@ def add_state_and_nonce_to_session(request, state, params):
         'added_on': time.time(),
     }
 
+
 def add_state_to_cookie(response, state):
     """
     Adds state to cookie for logout
@@ -110,4 +110,3 @@ def add_state_to_cookie(response, state):
     response.set_signed_cookie('oidc_state', state)
 
     return response
-

--- a/mozilla_django_oidc/utils.py
+++ b/mozilla_django_oidc/utils.py
@@ -78,6 +78,9 @@ def add_state_and_nonce_to_session(request, state, params):
     # If the number of State/Nonce combinations reaches a certain threshold, remove the oldest
     # state by finding out
     # which element has the oldest "add_on" time.
+
+    # I think we can't do this as an OrderedDict because of the way
+    # Django stores session info?
     limit = import_from_settings('OIDC_MAX_STATES', 50)
     if len(request.session['oidc_states']) >= limit:
         LOGGER.info(
@@ -97,3 +100,13 @@ def add_state_and_nonce_to_session(request, state, params):
         'nonce': nonce,
         'added_on': time.time(),
     }
+
+def add_state_to_cookie(request, state):
+    """
+    Adds state to cookie for logout
+    """
+
+    # TODO: Does this overwrite an existing state cookie?
+
+    request.set_cookie("oidc_state", state)
+

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -192,8 +192,6 @@ class OIDCAuthenticationRequestView(View):
 
         add_state_and_nonce_to_session(request, state, params)
 
-        add_state_to_cookie(request, state)
-
         request.session['oidc_login_next'] = get_next_url(request, redirect_field_name)
 
         query = urlencode(params)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -251,7 +251,8 @@ class OIDCLogoutView(View):
 
 
             session = request.session
-            LOGGER.debug("OIDCLogoutView.session", json.dumps(session))
+            LOGGER.debug("OIDCLogoutView.session.items()", session.items())
+            LOGGER.debug("OIDCLogoutView.session.keys()", session.keys())
 
             id_token_hint = session.get("oidc_id_token")
             LOGGER.debug("OIDCLogoutView.post.id_token_hint", id_token_hint)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -58,7 +58,10 @@ class OIDCAuthenticationCallbackView(View):
         expiration_interval = self.get_settings('OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS', 60 * 15)
         self.request.session['oidc_id_token_expiration'] = time.time() + expiration_interval
 
-        return HttpResponseRedirect(self.success_url)
+        response = HttpResponseRedirect(self.success_url)
+        response.set_cookie("test", "test")
+
+        return response
 
     def get(self, request):
         """Callback handler for OIDC authorization code flow"""

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -222,6 +222,8 @@ class OIDCLogoutView(View):
             if logout_from_op:
                 logout_url = import_string(logout_from_op)(request)
 
+            # Log out of login.gov?
+
             # Log out the Django user if they were logged in.
             auth.logout(request)
 

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -1,6 +1,7 @@
 import time
 import requests
 import logging
+import json
 
 from django.contrib import auth
 from django.core.exceptions import SuspiciousOperation

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -58,10 +58,7 @@ class OIDCAuthenticationCallbackView(View):
         expiration_interval = self.get_settings('OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS', 60 * 15)
         self.request.session['oidc_id_token_expiration'] = time.time() + expiration_interval
 
-        response = HttpResponseRedirect(self.success_url)
-        response.set_cookie("test", "test")
-
-        return response
+        return HttpResponseRedirect(self.success_url)
 
     def get(self, request):
         """Callback handler for OIDC authorization code flow"""
@@ -199,7 +196,10 @@ class OIDCAuthenticationRequestView(View):
 
         query = urlencode(params)
         redirect_url = '{url}?{query}'.format(url=self.OIDC_OP_AUTH_ENDPOINT, query=query)
-        return HttpResponseRedirect(redirect_url)
+
+        response = HttpResponseRedirect(redirect_url)
+        add_state_to_cookie(response, state)
+        return response
 
     def get_extra_params(self, request):
         return self.get_settings('OIDC_AUTH_REQUEST_EXTRA_PARAMS', {})

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -240,9 +240,6 @@ class OIDCLogoutView(View):
             # post_logout_redirect_uri=${REDIRECT_URI}&
             # state=abcdefghijklmnopabcdefghijklmnop
 
-            session = request.session
-            LOGGER.debug("OIDCLogoutView.post.session", session)
-
             # id_token_hint
             # An id_token value from the token endpoint response.
 
@@ -251,6 +248,19 @@ class OIDCLogoutView(View):
 
             # state
             # A unique value at least 22 characters in length used for maintaining state between the request and the callback. This value will be returned to the client on a successful logout.
+
+
+            session = request.session
+            LOGGER.debug("OIDCLogoutView.session", json.dumps(session))
+
+            id_token_hint = session.get("oidc_id_token")
+            LOGGER.debug("OIDCLogoutView.post.id_token_hint", id_token_hint)
+
+            # logout_payload = {
+            #     "id_token_hint": id_token_hint,
+            #     "post_logout_redirect_uri": "", # TODO: Do we do this ourselves?
+            #     "state": state
+            # }
 
             # Log out the Django user if they were logged in.
             auth.logout(request)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -261,7 +261,7 @@ class OIDCLogoutView(View):
 
             logout_payload = {
                 "id_token_hint": id_token_hint,
-                "post_logout_redirect_uri": logout_url, # TODO: Do we do this ourselves?
+                "post_logout_redirect_uri": "", # TODO: Do we do this ourselves?
                 "state": state
             }
 

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -246,7 +246,7 @@ class OIDCLogoutView(View):
             id_token_hint = session.get("oidc_id_token")
             LOGGER.debug("OIDCLogoutView.post.id_token_hint: ", id_token_hint)
 
-            state = request.get_signed_cookie("oidc_state")
+            state = request.get_signed_cookie("oidc_state", None)
 
             # TODO: What if the user has cookies blocked?
             # End all sessions? Get latest state

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -223,6 +223,7 @@ class OIDCLogoutView(View):
                 logout_url = import_string(logout_from_op)(request)
 
             # Log out of login.gov?
+            # modify auth.logout()
 
             # Log out the Django user if they were logged in.
             auth.logout(request)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -263,15 +263,19 @@ class OIDCLogoutView(View):
 
             state = request.get_signed_cookie("oidc_state")
 
+            # TODO: What if the user has cookies blocked?
+            # End all sessions? Get latest state
+
             logout_payload = {
                 "id_token_hint": id_token_hint,
-                "post_logout_redirect_uri": "", # TODO: Do we do this ourselves?
+                "post_logout_redirect_uri": logout_url, # TODO: Do we do this ourselves?
                 "state": state
             }
 
             LOGGER.debug("OIDCLogoutView.post.logout_payload: ", json.dumps(logout_payload))
 
             response = requests.post(self.OIDC_OP_LOGOUT_URL, data=logout_payload)
+
 
             # Log out the Django user if they were logged in.
             auth.logout(request)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -233,27 +233,11 @@ class OIDCLogoutView(View):
         if request.user.is_authenticated:
             # Check if a method exists to build the URL to log out the user
             # from the OP.
-            # logout_from_op = self.get_settings('OIDC_OP_LOGOUT_URL_METHOD', '')
-            # if logout_from_op:
-            #     logout_url = import_string(logout_from_op)(request)
+            logout_from_op = self.get_settings('OIDC_OP_LOGOUT_URL_METHOD', '')
+            if logout_from_op:
+                logout_url = import_string(logout_from_op)(request)
 
             # Log out of login.gov
-
-            # Example
-            # https://idp.int.identitysandbox.gov/openid_connect/logout?
-            # id_token_hint=eyJ0...g&
-            # post_logout_redirect_uri=${REDIRECT_URI}&
-            # state=abcdefghijklmnopabcdefghijklmnop
-
-            # id_token_hint
-            # An id_token value from the token endpoint response.
-
-            # post_logout_redirect_uri
-            # The URI Login.gov will redirect to after logout.
-
-            # state
-            # A unique value at least 22 characters in length used for maintaining state between the request and the callback. This value will be returned to the client on a successful logout.
-
 
             session = request.session
             LOGGER.debug("OIDCLogoutView.session.items(): ", session.items())
@@ -276,7 +260,6 @@ class OIDCLogoutView(View):
             LOGGER.debug("OIDCLogoutView.post.logout_payload: ", json.dumps(logout_payload))
 
             response = requests.post(self.OIDC_OP_LOGOUT_URL, data=logout_payload)
-
 
             # Log out the Django user if they were logged in.
             auth.logout(request)

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -19,6 +19,7 @@ from django.views.generic import View
 
 from mozilla_django_oidc.utils import (absolutify,
                                        add_state_and_nonce_to_session,
+                                       add_state_to_cookie,
                                        import_from_settings)
 
 from urllib.parse import urlencode
@@ -190,6 +191,8 @@ class OIDCAuthenticationRequestView(View):
             })
 
         add_state_and_nonce_to_session(request, state, params)
+
+        add_state_to_cookie(request, state)
 
         request.session['oidc_login_next'] = get_next_url(request, redirect_field_name)
 

--- a/mozilla_django_oidc/views.py
+++ b/mozilla_django_oidc/views.py
@@ -251,21 +251,28 @@ class OIDCLogoutView(View):
 
 
             session = request.session
-            LOGGER.debug("OIDCLogoutView.session.items()", session.items())
-            LOGGER.debug("OIDCLogoutView.session.keys()", session.keys())
+            LOGGER.debug("OIDCLogoutView.session.items(): ", session.items())
+            LOGGER.debug("OIDCLogoutView.session.keys(): ", session.keys())
 
             id_token_hint = session.get("oidc_id_token")
-            LOGGER.debug("OIDCLogoutView.post.id_token_hint", id_token_hint)
+            LOGGER.debug("OIDCLogoutView.post.id_token_hint: ", id_token_hint)
 
-            # logout_payload = {
-            #     "id_token_hint": id_token_hint,
-            #     "post_logout_redirect_uri": "", # TODO: Do we do this ourselves?
-            #     "state": state
-            # }
+            state = request.get_signed_cookie("oidc_state")
+
+            logout_payload = {
+                "id_token_hint": id_token_hint,
+                "post_logout_redirect_uri": logout_url, # TODO: Do we do this ourselves?
+                "state": state
+            }
+
+            LOGGER.debug("OIDCLogoutView.post.logout_payload: ", json.dumps(logout_payload))
+
+            response = requests.post(self.OIDC_OP_LOGOUT_URL, data=logout_payload)
 
             # Log out the Django user if they were logged in.
             auth.logout(request)
 
+        # TODO: Which redirect is happening? Ok to do both?
         return HttpResponseRedirect(logout_url)
 
     def get(self, request):

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requirements = [
     'josepy',
     'requests',
     'cryptography',
+    'pyjwt',
 ]
 
 setup(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -7,6 +7,7 @@ from mock import patch
 from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.urls import reverse
 from django.test import RequestFactory, TestCase, override_settings, Client
 
@@ -564,6 +565,7 @@ class OIDCLogoutViewTestCase(TestCase):
     def test_get_anonymous_user(self):
         url = reverse('oidc_logout')
         request = self.factory.post(url)
+        request.session = {'oidc_state': '123'}
         request.user = AnonymousUser()
         logout_view = views.OIDCLogoutView.as_view()
 
@@ -576,6 +578,7 @@ class OIDCLogoutViewTestCase(TestCase):
         user = User.objects.create_user('example_username')
         url = reverse('oidc_logout')
         request = self.factory.post(url)
+        request.session = {'oidc_state': '123'}
         request.user = user
         logout_view = views.OIDCLogoutView.as_view()
 
@@ -592,6 +595,7 @@ class OIDCLogoutViewTestCase(TestCase):
         user = User.objects.create_user('example_username')
         url = reverse('oidc_logout')
         request = self.factory.post(url)
+        request.session = {'oidc_state': '123'}
         request.user = user
         logout_view = views.OIDCLogoutView.as_view()
 


### PR DESCRIPTION
Issue https://github.com/fecgov/fecfile-web-api/issues/90

### Testing
**Run automated tests**
```
$ virtualenv -p /path/to/bin/python3.8 venv
$ source venv
(venv) $ pip install -r requirements/requirements_dev.txt
(venv) $ DJANGO_SETTINGS_MODULE=tests.settings django-admin.py test
```
**Test with demo app**
https://login-demo.app.cloud.gov/simpleapp/